### PR TITLE
Region filter now ignores 'Any' instead of searching for listing located in "Any"

### DIFF
--- a/packages/backend/src/services/PropertyService.ts
+++ b/packages/backend/src/services/PropertyService.ts
@@ -128,14 +128,26 @@ class PropertyService {
       where.commuteTime.lte = preferences.maxCommuteTime;
     }
 
-    // Regions filter
-    if (preferences.regions && preferences.regions.length > 0) {
-      const regions = preferences.regions.split(' ');
-      where.OR = regions.map(region => ({
-        addressLine2: {
-          contains: region,
-        },
-      }));
+// Regions filter
+    // Check if regions are provided and not empty, and not 'any'
+    if (
+      preferences.regions &&
+      preferences.regions.trim().length > 0 &&
+      preferences.regions.toLowerCase().trim() !== 'any'
+    ) {
+      const regions = preferences.regions
+        .toLowerCase()  // Convert to lowercase
+        .split(/\s+/) // Split by whitespace
+        .filter((region) => region !== 'any');  // Filter out 'any'
+
+      if (regions.length > 0) {
+        where.OR = regions.map((region) => ({
+          addressLine2: {
+            contains: region,
+            mode: 'insensitive',
+          },
+        }));
+      }
     }
 
     // Published date filter


### PR DESCRIPTION
What’s Changed:
	•	The string "Any" is now ignored entirely during region filtering.
	•	Multiple selected regions (e.g., "zetland redfern") still work using an OR match across addressLine2, case-insensitive even when "Any" is selected.

Why:
	•	Previously, if "Any" was present in the regions field, it was incorrectly interpreted literally and caused the backend to search for listings where the suburb was "Any" — returning no results.
	•	If "Any" is selected alongside other regions, only the valid regions are used — "Any" is silently excluded.

How to Test:
	•	On the frontend, use the suburb filter and:
	•	Select "Any" only → all regions should match.
	•	Select "Any" with other suburbs → results should reflect only the valid suburbs.
	•	Select specific suburbs → results should include matches from those suburbs.

Safety:
	•	No breaking changes.
	
============================================================================================

变更内容：
	•	在 PropertyService.ts 中更新了 regions 筛选逻辑：
	•	"Any" 字符串现在会被完全忽略。
	•	即使选择了 "Any"，多个地区（如 "zetland redfern"）依然会通过 OR 条件进行匹配，并对 addressLine2 字段进行不区分大小写的模糊匹配。

背景原因：
	•	之前如果 regions 字段中包含 "Any"，后端会错误地按字符串 “Any” 匹配地址中的 suburb，导致无法返回任何房源。
	•	如果 "Any" 与其他地区一同被选中，系统现在只会使用有效的地区名称，自动排除 “Any”，避免影响筛选结果。

测试方式：
	•	在前端使用地区筛选器，测试以下几种情况：
	•	仅选择 "Any" → 应该匹配所有地区房源。
	•	同时选择 "Any" 和其他地区 → 结果应仅基于有效地区。
	•	只选择具体地区 → 结果应只包含这些地区的房源。

安全性：
	•	无破坏性变更。
