### PR TITLE
Configure Next.js i18n locales

### DIFF
--- a/packages/frontend/next.config.ts
+++ b/packages/frontend/next.config.ts
@@ -13,6 +13,11 @@ if (process.env.NODE_ENV === 'development') {
 const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
 const nextConfig: NextConfig = {
+  i18n: {
+    locales: ['en', 'zh'],
+    defaultLocale: 'en',
+    localeDetection: false,
+  },
   eslint: {
     ignoreDuringBuilds: false,
   },


### PR DESCRIPTION
## Summary
- configure Next.js i18n settings so the default /about route renders in English while /zh/about renders in Chinese

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee346fbcb48328a8ab2a521936501a