### PR TITLE
fix:search result unclear if click filters search

### DIFF
--- a/packages/frontend/src/components/SearchBar.tsx
+++ b/packages/frontend/src/components/SearchBar.tsx
@@ -168,7 +168,11 @@ export default function SearchBar() {
               setOrDelete('university', targetSchool);
               setOrDelete('priceMax', maxPrice);
               setOrDelete('commuteMax', commuteTime);
-              setOrDelete('bedroomsMax', numBedrooms);
+              setOrDelete('bedroomsMin', numBedrooms);
+
+              if (parseInt(numBedrooms) < 5) {
+                setOrDelete('bedroomsMax', numBedrooms);
+              }
 
               if (pathname === `/${locale}/search`) {
                 params.set('filters', 'open');


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
When users select bedroom count on the homepage and then use the filter modal to add bathroom criteria, the search results incorrectly include properties with fewer bedrooms than specified.

**Steps to reproduce:**
1. On homepage, select "2 bedrooms" 
2. Click filter button
3. Set bathroom count to "1" in filter modal
4. Click search
5. **Issue**: Results include 1-bedroom properties (should only show 2-bedroom properties)

### Root Cause
Inconsistent parameter handling between SearchBar's submit action and filter button click:

- **Submit search**: Sets both `bedroomsMin=2` and `bedroomsMax=2` (correct)
- **Filter button**: Only sets `bedroomsMax=2`, missing `bedroomsMin` (incorrect)

This caused the search criteria to become "bedrooms ≤ 2" instead of "bedrooms = 2".

### Solution
Updated the filter button click handler in `SearchBar.tsx` to match the submit logic:

**Before:**
```typescript
setOrDelete('bedroomsMax', numBedrooms);
```

**After:**
```typescript
setOrDelete('bedroomsMin', numBedrooms);
if (parseInt(numBedrooms) < 5) {
  setOrDelete('bedroomsMax', numBedrooms);
}
```

### Testing
- ✅ Homepage bedroom selection + filter modal now maintains exact bedroom count
- ✅ Search results correctly filter by exact bedroom count (not just maximum)
- ✅ No regression in existing search functionality